### PR TITLE
SQLAlchemy>=0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask
 markdown
 Flask-Assets
 Flask-Mail
+SQLAlchemy>=0.9
 Flask-SQLAlchemy
 jsmin
 Flask-OpenID


### PR DESCRIPTION
Use of load_only in https://github.com/hasgeek/lastuser/blob/master/lastuser_core/models/client.py#L7 requires SQLAlchemy to be atleast version 0.9 as it was introduced in the said version http://docs.sqlalchemy.org/en/rel_0_9/changelog/migration_09.html#new-query-options-api-load-only-option